### PR TITLE
chore: make footer responsive, up threshold for when search appears

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -80,16 +80,20 @@ export default function Footer() {
     <footer className="body-font sticky top-[100vh] text-gray-700">
       <div className="container mx-auto flex max-w-7xl flex-col items-center px-8 py-4 sm:flex-row">
         <p className="mt-4 text-xs text-gray-500 sm:mt-0">
-          {ref() && (
-            <>
-              <a href={refURL()} className="text-violet-500">
-                {ref()}
-              </a>
-              &nbsp;|&nbsp;
-            </>
-          )}
-          &copy; {new Date().getFullYear()} Flipt Software Inc. All rights
-          reserved.
+          <span className="hidden sm:inline">
+            {ref() && (
+              <>
+                <a href={refURL()} className="text-violet-500">
+                  {ref()}
+                </a>
+                &nbsp;|&nbsp;
+              </>
+            )}
+          </span>
+          <span className="block sm:inline">
+            &copy; {new Date().getFullYear()} Flipt Software Inc. All rights
+            reserved.
+          </span>
         </p>
         <span className="mt-4 inline-flex justify-center space-x-5 sm:ml-auto sm:mt-0 sm:justify-start">
           {social.map((item) => (

--- a/src/components/flags/FlagTable.tsx
+++ b/src/components/flags/FlagTable.tsx
@@ -26,6 +26,8 @@ export default function FlagTable(props: FlagTableProps) {
   const { flags } = props;
 
   const pageSize = 20;
+  const searchThreshold = 10;
+
   const [sorting, setSorting] = useState<SortingState>([]);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -139,7 +141,7 @@ export default function FlagTable(props: FlagTableProps) {
 
   return (
     <>
-      {flags.length > 15 && (
+      {flags.length >= searchThreshold && (
         <Searchbox className="mb-4" value={filter ?? ''} onChange={setFilter} />
       )}
       <table className="divide-y divide-gray-300">

--- a/src/components/segments/SegmentTable.tsx
+++ b/src/components/segments/SegmentTable.tsx
@@ -26,6 +26,8 @@ export default function SegmentTable(props: SegmentTableProps) {
   const { segments } = props;
 
   const pageSize = 20;
+  const searchThreshold = 10;
+
   const [sorting, setSorting] = useState<SortingState>([]);
   const [pagination, setPagination] = useState<PaginationState>({
     pageIndex: 0,
@@ -132,7 +134,7 @@ export default function SegmentTable(props: SegmentTableProps) {
 
   return (
     <>
-      {segments.length > 15 && (
+      {segments.length >= searchThreshold && (
         <Searchbox className="mb-4" value={filter ?? ''} onChange={setFilter} />
       )}
       <table className="divide-y divide-gray-300">


### PR DESCRIPTION
Fixes: FLI-158

![Kapture 2023-01-10 at 16 17 11](https://user-images.githubusercontent.com/209477/211664836-1b4f0c3a-f581-4968-bd59-0e74d8dfc3bf.gif)

- Makes footer responsive on mobile/small screens
- Lowers threshold for when searchbox appears (now after 15 items in table) per beta user feedback