### PR TITLE
fix: dependency warnings in useEffectHooks

### DIFF
--- a/src/app/console/Console.tsx
+++ b/src/app/console/Console.tsx
@@ -53,7 +53,7 @@ export default function Console() {
     } catch (err) {
       setError(err instanceof Error ? err : Error(String(err)));
     }
-  }, []);
+  }, [clearError, setError]);
 
   const handleSubmit = (values: IConsole) => {
     const { flagKey, entityId, context } = values;

--- a/src/app/flags/Evaluation.tsx
+++ b/src/app/flags/Evaluation.tsx
@@ -102,7 +102,7 @@ export default function Evaluation() {
     });
 
     setRules(rules);
-  }, [rulesVersion]);
+  }, [flag]);
 
   const incrementRulesVersion = () => {
     setRulesVersion(rulesVersion + 1);
@@ -156,7 +156,7 @@ export default function Evaluation() {
 
   useEffect(() => {
     loadData();
-  }, [rulesVersion]);
+  }, [loadData, rulesVersion]);
 
   return (
     <>

--- a/src/app/flags/Flag.tsx
+++ b/src/app/flags/Flag.tsx
@@ -42,7 +42,7 @@ export default function Flag() {
       .catch((err) => {
         setError(err);
       });
-  }, [flagVersion]);
+  }, [clearError, flag.key, setError]);
 
   const incrementFlagVersion = () => {
     setFlagVersion(flagVersion + 1);

--- a/src/app/flags/Flags.tsx
+++ b/src/app/flags/Flags.tsx
@@ -20,7 +20,7 @@ export default function Flags() {
       return;
     }
     clearError();
-  }, error);
+  }, [clearError, error, setError]);
 
   return (
     <>

--- a/src/app/segments/Segment.tsx
+++ b/src/app/segments/Segment.tsx
@@ -37,7 +37,7 @@ export default function Segment() {
   const navigate = useNavigate();
 
   const [segment, setSegment] = useState<ISegment>(useLoaderData() as ISegment);
-  const [segmentVerison, setSegmentVersion] = useState(0);
+  const [segmentVersion, setSegmentVersion] = useState(0);
 
   const [showConstraintForm, setShowConstraintForm] = useState<boolean>(false);
   const [editingConstraint, setEditingConstraint] =
@@ -60,15 +60,15 @@ export default function Segment() {
       .catch((err) => {
         setError(err);
       });
-  }, [segmentVerison]);
+  }, [clearError, segment.key, setError]);
 
   const incrementSegmentVersion = () => {
-    setSegmentVersion(segmentVerison + 1);
+    setSegmentVersion(segmentVersion + 1);
   };
 
   useEffect(() => {
     fetchSegment();
-  }, [segmentVerison, fetchSegment]);
+  }, [segmentVersion, fetchSegment]);
 
   const constraintTypeToLabel = (t: string) =>
     ComparisonType[t as keyof typeof ComparisonType];

--- a/src/app/segments/Segments.tsx
+++ b/src/app/segments/Segments.tsx
@@ -20,7 +20,7 @@ export default function Segments() {
       return;
     }
     clearError();
-  }, error);
+  }, [clearError, error, setError]);
 
   return (
     <>


### PR DESCRIPTION
Fix linter errors for useEffect deps

### Before

```console
> flipt-ui@0.1.0 lint
> eslint src


/Users/markphelps/workspace/flipt-ui/src/app/console/Console.tsx
  56:6  warning  React Hook useCallback has missing dependencies: 'clearError' and 'setError'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

/Users/markphelps/workspace/flipt-ui/src/app/flags/Evaluation.tsx
  105:6  warning  React Hook useCallback has a missing dependency: 'flag'. Either include it or remove the dependency array    react-hooks/exhaustive-deps
  159:6  warning  React Hook useEffect has a missing dependency: 'loadData'. Either include it or remove the dependency array  react-hooks/exhaustive-deps

/Users/markphelps/workspace/flipt-ui/src/app/flags/Flag.tsx
  45:6  warning  React Hook useCallback has missing dependencies: 'clearError', 'flag.key', and 'setError'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

/Users/markphelps/workspace/flipt-ui/src/app/flags/Flags.tsx
  23:6  warning  React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies  react-hooks/exhaustive-deps
  23:6  warning  React Hook useEffect has missing dependencies: 'clearError', 'error', and 'setError'. Either include them or remove the dependency array                              react-hooks/exhaustive-deps

/Users/markphelps/workspace/flipt-ui/src/app/segments/Segment.tsx
  63:6  warning  React Hook useCallback has missing dependencies: 'clearError', 'segment.key', and 'setError'. Either include them or remove the dependency array  react-hooks/exhaustive-deps

/Users/markphelps/workspace/flipt-ui/src/app/segments/Segments.tsx
  23:6  warning  React Hook useEffect was passed a dependency list that is not an array literal. This means we can't statically verify whether you've passed the correct dependencies  react-hooks/exhaustive-deps
  23:6  warning  React Hook useEffect has missing dependencies: 'clearError', 'error', and 'setError'. Either include them or remove the dependency array                              react-hooks/exhaustive-deps

✖ 9 problems (0 errors, 9 warnings)
```

### After

```console
> flipt-ui@0.1.0 lint
> eslint src
```