### PR TITLE
chore: change doc icon

### DIFF
--- a/src/components/Nav.tsx
+++ b/src/components/Nav.tsx
@@ -1,8 +1,7 @@
 import {
-  ArrowTopRightOnSquareIcon,
+  BookOpenIcon,
   CodeBracketIcon,
   FlagIcon,
-  QuestionMarkCircleIcon,
   UsersIcon
 } from '@heroicons/react/24/outline';
 import { NavLink } from 'react-router-dom';
@@ -34,10 +33,6 @@ function NavItem(props: NavItemProps) {
         aria-hidden="true"
       />
       {name}
-      <ArrowTopRightOnSquareIcon
-        className="ml-2 h-4 w-4 text-white hover:bg-gray-50 md:text-gray-400"
-        aria-hidden="true"
-      />
     </a>
   ) : (
     <NavLink
@@ -98,7 +93,7 @@ export default function Nav(props: NavProps) {
     {
       name: 'Documentation',
       to: 'https://flipt.io/docs?utm_source=app',
-      Icon: QuestionMarkCircleIcon,
+      Icon: BookOpenIcon,
       external: true
     }
   ];


### PR DESCRIPTION
Changes documentation icon, removes 'external' icon

## Before
<img width="258" alt="CleanShot 2023-01-19 at 22 17 27@2x" src="https://user-images.githubusercontent.com/209477/213610577-8b8a1591-7eee-4a98-8060-9752188e4f7a.png">

## After
<img width="253" alt="CleanShot 2023-01-19 at 22 17 09@2x" src="https://user-images.githubusercontent.com/209477/213610658-a3171f64-6931-4a86-b796-a3070a38d3e4.png">
