### PR TITLE
fix(fontawesome): set config.autoAddCss = false

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,6 +2,9 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
+import { config } from '@fortawesome/fontawesome-svg-core';
+
+config.autoAddCss = false
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,8 +1,8 @@
+import { config } from '@fortawesome/fontawesome-svg-core';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
 import './index.css';
-import { config } from '@fortawesome/fontawesome-svg-core';
 
 config.autoAddCss = false;
 

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -4,7 +4,7 @@ import App from './App';
 import './index.css';
 import { config } from '@fortawesome/fontawesome-svg-core';
 
-config.autoAddCss = false
+config.autoAddCss = false;
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>


### PR DESCRIPTION
This fixes one of the blocked resource-related errors we see when we add CSP to Flipt.

https://fontawesome.com/v5/docs/web/other-topics/security#content-security-policy

Before:

<img width="1721" alt="Screenshot 2023-01-27 at 11 12 19" src="https://user-images.githubusercontent.com/1253326/215081961-7de657e4-9ec6-473e-85c9-622c8285aba1.png">

After:

<img width="1721" alt="Screenshot 2023-01-27 at 11 59 35" src="https://user-images.githubusercontent.com/1253326/215081979-8713ee54-2edc-46c5-bbc0-14032ff29ca2.png">
