### PR TITLE
feat: autofocus first input on forms open

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "lint": "eslint src"
+    "lint": "eslint src",
+    "format": "prettier --write .",
+    "format:check": "prettier --check ."
   },
   "dependencies": {
     "@dnd-kit/core": "^6.0.7",

--- a/src/app/flags/EditFlag.tsx
+++ b/src/app/flags/EditFlag.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon } from '@heroicons/react/24/outline';
-import { useState } from 'react';
+import { useRef, useState } from 'react';
 import { useOutletContext } from 'react-router-dom';
 import EmptyState from '~/components/EmptyState';
 import DeleteVariantPanel from '~/components/flags/DeleteVariantPanel';
@@ -27,13 +27,19 @@ export default function EditFlag() {
     useState<boolean>(false);
   const [deletingVariant, setDeletingVariant] = useState<IVariant | null>(null);
 
+  const variantFormRef = useRef(null);
   return (
     <>
       <FlagMenu flag={flag} selected="details" />
 
       {/* variant edit form */}
-      <Slideover open={showVariantForm} setOpen={setShowVariantForm}>
+      <Slideover
+        open={showVariantForm}
+        setOpen={setShowVariantForm}
+        ref={variantFormRef}
+      >
         <VariantForm
+          ref={variantFormRef}
           flagKey={flag.key}
           variant={editingVariant || undefined}
           setOpen={setShowVariantForm}

--- a/src/app/segments/Segment.tsx
+++ b/src/app/segments/Segment.tsx
@@ -1,6 +1,6 @@
 import { CalendarIcon } from '@heroicons/react/20/solid';
 import { formatDistanceToNowStrict, parseISO } from 'date-fns';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   LoaderFunctionArgs,
   useLoaderData,
@@ -75,11 +75,17 @@ export default function Segment() {
 
   const constraintOperatorToLabel = (o: string) => ConstraintOperators[o];
 
+  const constraintFormRef = useRef(null);
   return (
     <>
       {/* constraint edit form */}
-      <Slideover open={showConstraintForm} setOpen={setShowConstraintForm}>
+      <Slideover
+        open={showConstraintForm}
+        setOpen={setShowConstraintForm}
+        ref={constraintFormRef}
+      >
         <ConstraintForm
+          ref={constraintFormRef}
           segmentKey={segment.key}
           constraint={editingConstraint || undefined}
           setOpen={setShowConstraintForm}

--- a/src/components/Slideover.tsx
+++ b/src/components/Slideover.tsx
@@ -1,5 +1,5 @@
 import { Dialog, Transition } from '@headlessui/react';
-import { Fragment } from 'react';
+import { forwardRef, Fragment } from 'react';
 
 type SlideOverProps = {
   open: boolean;
@@ -7,12 +7,17 @@ type SlideOverProps = {
   children: React.ReactNode;
 };
 
-export default function Slideover(props: SlideOverProps) {
+const SlideOver = forwardRef((props: SlideOverProps, ref: any) => {
   const { open, setOpen } = props;
 
   return (
     <Transition.Root show={open} as={Fragment}>
-      <Dialog as="div" className="relative z-10" onClose={setOpen}>
+      <Dialog
+        as="div"
+        className="relative z-10"
+        onClose={setOpen}
+        initialFocus={ref}
+      >
         <div className="fixed inset-0" />
 
         <div className="fixed inset-0 overflow-hidden">
@@ -37,4 +42,7 @@ export default function Slideover(props: SlideOverProps) {
       </Dialog>
     </Transition.Root>
   );
-}
+});
+
+SlideOver.displayName = 'SlideOver';
+export default SlideOver;

--- a/src/components/flags/FlagForm.tsx
+++ b/src/components/flags/FlagForm.tsx
@@ -95,6 +95,7 @@ export default function FlagForm(props: FlagFormProps) {
                     className="mt-1"
                     name="name"
                     id="name"
+                    autoFocus={isNew}
                     handleChange={(e) => {
                       // check if the name and key are currently in sync
                       // we do this so we don't override a custom key value

--- a/src/components/flags/VariantForm.tsx
+++ b/src/components/flags/VariantForm.tsx
@@ -1,6 +1,7 @@
 import { Dialog } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Form, Formik } from 'formik';
+import { forwardRef } from 'react';
 import * as Yup from 'yup';
 import Button from '~/components/forms/Button';
 import Input from '~/components/forms/Input';
@@ -20,7 +21,7 @@ type VariantFormProps = {
   onSuccess: () => void;
 };
 
-export default function VariantForm(props: VariantFormProps) {
+const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
   const { setOpen, flagKey, variant, onSuccess } = props;
   const isNew = variant === undefined;
   const title = isNew ? 'New Variant' : 'Edit Variant';
@@ -98,7 +99,7 @@ export default function VariantForm(props: VariantFormProps) {
                   </label>
                 </div>
                 <div className="sm:col-span-2">
-                  <Input name="key" id="key" />
+                  <Input name="key" id="key" forwardRef={ref} />
                 </div>
               </div>
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
@@ -176,4 +177,7 @@ export default function VariantForm(props: VariantFormProps) {
       )}
     </Formik>
   );
-}
+});
+
+VariantForm.displayName = 'VariantForm';
+export default VariantForm;

--- a/src/components/forms/Input.tsx
+++ b/src/components/forms/Input.tsx
@@ -6,27 +6,29 @@ type InputProps = {
   name: string;
   type?: string;
   className?: string;
-  autocomplete?: boolean;
-  disabled?: boolean;
+  autoComplete?: boolean;
+  forwardRef?: React.RefObject<HTMLInputElement>;
   handleChange?: (e: React.ChangeEvent<HTMLInputElement>) => void;
-};
+} & React.InputHTMLAttributes<HTMLInputElement>;
 
 export default function Input(props: InputProps) {
   const {
     id,
     type = 'text',
-    className,
+    className = '',
     handleChange,
-    autocomplete = false,
-    disabled = false
+    autoComplete = false,
+    forwardRef,
+    ...rest
   } = props;
 
   const [field, meta] = useField(props);
-  const hasError = meta.touched && meta.error;
+  const hasError = !!(meta.touched && meta.error);
 
   return (
     <>
       <input
+        ref={forwardRef}
         className={classNames(
           hasError ? 'border-red-400' : 'border-gray-300',
           `${className} block w-full rounded-md shadow-sm focus:border-violet-300 focus:ring-violet-300 disabled:cursor-not-allowed disabled:border-gray-200 disabled:bg-gray-50 disabled:text-gray-500 sm:text-sm`
@@ -38,8 +40,8 @@ export default function Input(props: InputProps) {
           field.onChange(e);
           handleChange && handleChange(e);
         }}
-        autoComplete={autocomplete ? 'on' : 'off'}
-        disabled={disabled}
+        autoComplete={autoComplete ? 'on' : 'off'}
+        {...rest}
       />
       {meta.touched && meta.error ? (
         <div className="mt-1 text-sm text-red-500">{meta.error}</div>

--- a/src/components/segments/ConstraintForm.tsx
+++ b/src/components/segments/ConstraintForm.tsx
@@ -1,7 +1,7 @@
 import { Dialog } from '@headlessui/react';
 import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Form, Formik, useField, useFormikContext } from 'formik';
-import { useEffect, useState } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import * as Yup from 'yup';
 import Button from '~/components/forms/Button';
 import Input from '~/components/forms/Input';
@@ -132,7 +132,7 @@ type ConstraintFormProps = {
   onSuccess: () => void;
 };
 
-export default function ConstraintForm(props: ConstraintFormProps) {
+const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
   const { setOpen, segmentKey, constraint, onSuccess } = props;
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
@@ -214,7 +214,7 @@ export default function ConstraintForm(props: ConstraintFormProps) {
                   </label>
                 </div>
                 <div className="sm:col-span-2">
-                  <Input name="property" id="property" />
+                  <Input name="property" id="property" forwardRef={ref} />
                 </div>
               </div>
               <div className="space-y-1 px-4 sm:grid sm:grid-cols-3 sm:gap-4 sm:space-y-0 sm:px-6 sm:py-5">
@@ -286,4 +286,7 @@ export default function ConstraintForm(props: ConstraintFormProps) {
       )}
     </Formik>
   );
-}
+});
+
+ConstraintForm.displayName = 'ConstraintForm';
+export default ConstraintForm;

--- a/src/components/segments/SegmentForm.tsx
+++ b/src/components/segments/SegmentForm.tsx
@@ -93,6 +93,7 @@ export default function SegmentForm(props: SegmentFormProps) {
                   className="mt-1"
                   name="name"
                   id="name"
+                  autoFocus={isNew}
                   handleChange={(e) => {
                     // check if the name and key are currently in sync
                     // we do this so we don't override a custom key value


### PR DESCRIPTION
Fixes: FLI-143

Autofocus first field input on form load for:
- New Flag: name
- New Segment: name
- Variant: key
- Constraint: property

Also add `npm run format` and `npm run format:check` tasks for prettier

![Kapture 2023-02-02 at 13 04 04](https://user-images.githubusercontent.com/209477/216408564-225b7f95-2c30-43b1-8b6a-3f96ccd878d5.gif)
