### PR TITLE
fix: Truncate Keys

### DIFF
--- a/src/components/flags/FlagTable.tsx
+++ b/src/components/flags/FlagTable.tsx
@@ -17,6 +17,7 @@ import { Link } from 'react-router-dom';
 import Pagination from '~/components/Pagination';
 import Searchbox from '~/components/Searchbox';
 import { IFlag } from '~/types/Flag';
+import { truncateKey } from '~/utils/helpers';
 
 type FlagTableProps = {
   flags: IFlag[];
@@ -42,7 +43,7 @@ export default function FlagTable(props: FlagTableProps) {
       header: 'Key',
       cell: (info) => (
         <Link to={`/flags/${info.getValue()}`} className="text-violet-500">
-          {info.getValue()}
+          {truncateKey(info.getValue())}
         </Link>
       ),
       meta: {

--- a/src/components/rules/RuleForm.tsx
+++ b/src/components/rules/RuleForm.tsx
@@ -15,6 +15,7 @@ import { IDistributionVariant } from '~/types/Distribution';
 import { IFlag } from '~/types/Flag';
 import { ISegment, SelectableSegment } from '~/types/Segment';
 import { SelectableVariant } from '~/types/Variant';
+import { truncateKey } from '~/utils/helpers';
 import Loading from '../Loading';
 import MultiDistributionFormInputs from './distributions/MultiDistributionForm';
 import SingleDistributionFormInput from './distributions/SingleDistributionForm';
@@ -188,7 +189,7 @@ export default function RuleForm(props: RuleFormProps) {
                       placeholder="Select or search for a segment"
                       values={segments.map((s) => ({
                         ...s,
-                        filterValue: s.key,
+                        filterValue: truncateKey(s.key),
                         displayValue: s.name
                       }))}
                       selected={selectedSegment}
@@ -273,7 +274,7 @@ export default function RuleForm(props: RuleFormProps) {
                   <p className="mt-1 px-4 text-center text-sm text-gray-500 sm:px-6 sm:py-5">
                     Flag{' '}
                     <Link to={`/flags/${flag.key}`} className="text-violet-500">
-                      {flag.key}
+                      {truncateKey(flag.key)}
                     </Link>{' '}
                     has no variants. You can add variants in the details
                     section.

--- a/src/components/segments/SegmentTable.tsx
+++ b/src/components/segments/SegmentTable.tsx
@@ -17,6 +17,7 @@ import { Link } from 'react-router-dom';
 import Pagination from '~/components/Pagination';
 import Searchbox from '~/components/Searchbox';
 import { ISegment, SegmentMatchType } from '~/types/Segment';
+import { truncateKey } from '~/utils/helpers';
 
 type SegmentTableProps = {
   segments: ISegment[];
@@ -42,7 +43,7 @@ export default function SegmentTable(props: SegmentTableProps) {
       header: 'Key',
       cell: (info) => (
         <Link to={info.getValue()} className="text-violet-500">
-          {info.getValue()}
+          {truncateKey(info.getValue())}
         </Link>
       ),
       meta: {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -16,3 +16,7 @@ export function stringAsKey(str: string) {
 
   // return temp;
 }
+
+export function truncateKey(str: string, len: number = 25): string {
+  return str.length > len ? str.substring(0, len) + '...' : str;
+}


### PR DESCRIPTION
FLI-192: Fixes issue where long key lengths cause formatting problems in the UI.

- Added helper method to allow for key/string truncating with variable length parameter
- Implemented key truncating on Segment and Flag tables, as well as Segment drop down 