### PR TITLE
chore: type some more resp objects; update highlightjs call

### DIFF
--- a/src/app/console/Console.tsx
+++ b/src/app/console/Console.tsx
@@ -70,7 +70,7 @@ export default function Console() {
   };
 
   useEffect(() => {
-    hljs.initHighlighting();
+    hljs.highlightAll();
   }, [response]);
 
   useEffect(() => {

--- a/src/app/flags/Flag.tsx
+++ b/src/app/flags/Flag.tsx
@@ -36,7 +36,7 @@ export default function Flag() {
 
   const fetchFlag = useCallback(() => {
     getFlag(flag.key)
-      .then((flag) => {
+      .then((flag: IFlag) => {
         setFlag(flag);
         clearError();
       })

--- a/src/app/segments/Segment.tsx
+++ b/src/app/segments/Segment.tsx
@@ -52,7 +52,7 @@ export default function Segment() {
 
   const fetchSegment = useCallback(() => {
     getSegment(segment.key)
-      .then((segment) => {
+      .then((segment: ISegment) => {
         setSegment(segment);
         clearError();
       })

--- a/src/app/settings/tokens/Tokens.tsx
+++ b/src/app/settings/tokens/Tokens.tsx
@@ -10,7 +10,7 @@ import Slideover from '~/components/Slideover';
 import Well from '~/components/Well';
 import { deleteToken, listAuthMethods, listTokens } from '~/data/api';
 import { useError } from '~/data/hooks/error';
-import { IAuthMethod } from '~/types/Auth';
+import { IAuthMethod, IAuthMethodList } from '~/types/Auth';
 import {
   IAuthToken,
   IAuthTokenInternal,
@@ -30,7 +30,7 @@ export default function Tokens() {
 
   const checkTokenAuthEnabled = useCallback(() => {
     listAuthMethods()
-      .then((resp) => {
+      .then((resp: IAuthMethodList) => {
         const authToken = resp.methods.find(
           (m: IAuthMethod) => m.method === 'METHOD_TOKEN' && m.enabled
         );

--- a/src/types/Auth.ts
+++ b/src/types/Auth.ts
@@ -5,6 +5,10 @@ export interface IAuthMethod {
   metadata: { [key: string]: any };
 }
 
+export interface IAuthMethodList {
+  methods: IAuthMethod[];
+}
+
 export interface IAuth {
   id: string;
   method: string;


### PR DESCRIPTION
- adds some more type info to some `resp` objects
- updates a deprecated call to highlightJS: `Deprecated as of 10.6.0. initHighlighting() deprecated.  Use highlightAll() now. core.js:1003:10`