### PR TITLE
Namespaces Switch

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,13 +4,15 @@ import { SWRConfig } from 'swr';
 import ErrorLayout from './app/ErrorLayout';
 import EditFlag from './app/flags/EditFlag';
 import Evaluation from './app/flags/Evaluation';
-import Flag, { flagLoader } from './app/flags/Flag';
+import Flag from './app/flags/Flag';
 import NewFlag from './app/flags/NewFlag';
 import Layout from './app/Layout';
 import NotFoundLayout from './app/NotFoundLayout';
 import NewSegment from './app/segments/NewSegment';
-import Segment, { segmentLoader } from './app/segments/Segment';
+import Segment from './app/segments/Segment';
+import NamespaceProvider from './components/NamespaceProvider';
 import SessionProvider from './components/SessionProvider';
+import { request } from './data/api';
 
 const Flags = loadable(() => import('./app/flags/Flags'));
 const Segments = loadable(() => import('./app/segments/Segments'));
@@ -48,7 +50,6 @@ const router = createHashRouter([
       {
         path: 'flags/:flagKey',
         element: <Flag />,
-        loader: flagLoader,
         children: [
           {
             path: '',
@@ -70,8 +71,7 @@ const router = createHashRouter([
       },
       {
         path: 'segments/:segmentKey',
-        element: <Segment />,
-        loader: segmentLoader
+        element: <Segment />
       },
       {
         path: 'console',
@@ -103,56 +103,8 @@ const router = createHashRouter([
   }
 ]);
 
-const apiURL = '/api/v1';
-
 const fetcher = async (uri: String) => {
-  const res = await fetch(apiURL + uri);
-
-  class StatusError extends Error {
-    info: string;
-
-    status: number;
-
-    constructor(message: string, info: string, status: number) {
-      super(message);
-      this.info = info;
-      this.status = status;
-    }
-  }
-
-  // If the status code is not in the range 200-299,
-  // we still try to parse and throw it.
-  if (!res.ok) {
-    if (res.status === 401) {
-      window.localStorage.clear();
-      window.location.reload();
-    }
-
-    const contentType = res.headers.get('content-type');
-
-    if (!contentType || !contentType.includes('application/json')) {
-      const err = new StatusError(
-        'An unexpected error occurred.',
-        await res.text(),
-        res.status
-      );
-      console.log(err);
-      throw err;
-    }
-
-    let info = '';
-    info = await res.json();
-
-    const err = new StatusError(
-      'An error occurred while fetching the data.',
-      info,
-      res.status
-    );
-    console.log(err);
-    throw err;
-  }
-
-  return res.json();
+  return request('GET', '/api/v1' + uri);
 };
 
 export default function App() {
@@ -163,7 +115,9 @@ export default function App() {
       }}
     >
       <SessionProvider>
-        <RouterProvider router={router} />
+        <NamespaceProvider>
+          <RouterProvider router={router} />
+        </NamespaceProvider>
       </SessionProvider>
     </SWRConfig>
   );

--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { Navigate, Outlet } from 'react-router-dom';
 import ErrorNotification from '~/components/ErrorNotification';
 import Footer from '~/components/Footer';
@@ -6,22 +6,30 @@ import Header from '~/components/Header';
 import { NotificationProvider } from '~/components/NotificationProvider';
 import Sidebar from '~/components/Sidebar';
 import SuccessNotification from '~/components/SuccessNotification';
+import { listNamespaces } from '~/data/api';
+import { useError } from '~/data/hooks/error';
 import { useSession } from '~/data/hooks/session';
-
-const namespaces = [
-  {
-    key: 'default',
-    name: 'Default'
-  },
-  {
-    key: 'test',
-    name: 'Test'
-  }
-];
+import { INamespace } from '~/types/Namespace';
 
 function InnerLayout() {
   const { session } = useSession();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [namespaces, setNamespaces] = useState<INamespace[]>([]);
+
+  const { setError, clearError } = useError();
+
+  useEffect(() => {
+    if (!session) return;
+
+    listNamespaces()
+      .then((data) => {
+        setNamespaces(data.namespaces);
+        clearError();
+      })
+      .catch((err) => {
+        setError(err);
+      });
+  }, [clearError, session, setError]);
 
   if (!session) {
     return <Navigate to="/login" />;

--- a/src/app/console/Console.tsx
+++ b/src/app/console/Console.tsx
@@ -13,6 +13,7 @@ import Input from '~/components/forms/Input';
 import TextArea from '~/components/forms/TextArea';
 import { evaluate, listFlags } from '~/data/api';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import {
   jsonValidation,
   keyValidation,
@@ -29,11 +30,16 @@ export default function Console() {
   const [flags, setFlags] = useState<SelectableFlag[]>([]);
   const [selectedFlag, setSelectedFlag] = useState<SelectableFlag | null>(null);
   const [response, setResponse] = useState<string | null>(null);
+
   const { setError, clearError } = useError();
   const navigate = useNavigate();
 
+  const { currentNamespace } = useNamespace();
+
   const loadData = useCallback(async () => {
-    const initialFlagList = (await listFlags()) as IFlagList;
+    const initialFlagList = (await listFlags(
+      currentNamespace?.key
+    )) as IFlagList;
     const { flags } = initialFlagList;
 
     setFlags(
@@ -48,7 +54,7 @@ export default function Console() {
         };
       })
     );
-  }, []);
+  }, [currentNamespace?.key]);
 
   const handleSubmit = (values: IConsole) => {
     const { flagKey, entityId, context } = values;
@@ -60,7 +66,7 @@ export default function Console() {
       context: parsed
     };
 
-    evaluate(flagKey, rest)
+    evaluate(currentNamespace?.key, flagKey, rest)
       .then((resp) => {
         setResponse(JSON.stringify(resp, null, 2));
       })

--- a/src/app/flags/EditFlag.tsx
+++ b/src/app/flags/EditFlag.tsx
@@ -10,6 +10,7 @@ import Modal from '~/components/Modal';
 import MoreInfo from '~/components/MoreInfo';
 import Slideover from '~/components/Slideover';
 import { deleteVariant } from '~/data/api';
+import useNamespace from '~/data/hooks/namespace';
 import { IVariant } from '~/types/Variant';
 import { FlagProps } from './FlagProps';
 
@@ -23,6 +24,8 @@ export default function EditFlag() {
   const [deletingVariant, setDeletingVariant] = useState<IVariant | null>(null);
 
   const variantFormRef = useRef(null);
+
+  const { currentNamespace } = useNamespace();
 
   return (
     <>
@@ -59,7 +62,12 @@ export default function EditFlag() {
           panelType="Variant"
           setOpen={setShowDeleteVariantModal}
           handleDelete={
-            () => deleteVariant(flag.key, deletingVariant?.id ?? '') // TODO: Determine impact of blank ID param
+            () =>
+              deleteVariant(
+                currentNamespace?.key,
+                flag.key,
+                deletingVariant?.id ?? ''
+              ) // TODO: Determine impact of blank ID param
           }
           onSuccess={() => {
             setShowDeleteVariantModal(false);

--- a/src/app/flags/Flags.tsx
+++ b/src/app/flags/Flags.tsx
@@ -6,11 +6,17 @@ import EmptyState from '~/components/EmptyState';
 import FlagTable from '~/components/flags/FlagTable';
 import Button from '~/components/forms/Button';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import { IFlagList } from '~/types/Flag';
 
 export default function Flags() {
-  const { data, error } = useSWR<IFlagList>('/flags');
+  const { currentNamespace } = useNamespace();
+
+  const { data, error } = useSWR<IFlagList>(
+    `/namespaces/${currentNamespace.key}/flags`
+  );
   const flags = data?.flags;
+
   const navigate = useNavigate();
   const { setError, clearError } = useError();
 

--- a/src/app/segments/Segments.tsx
+++ b/src/app/segments/Segments.tsx
@@ -6,11 +6,17 @@ import EmptyState from '~/components/EmptyState';
 import Button from '~/components/forms/Button';
 import SegmentTable from '~/components/segments/SegmentTable';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import { ISegmentList } from '~/types/Segment';
 
 export default function Segments() {
-  const { data, error } = useSWR<ISegmentList>('/segments');
+  const { currentNamespace } = useNamespace();
+
+  const { data, error } = useSWR<ISegmentList>(
+    `/namespaces/${currentNamespace.key}/segments`
+  );
   const segments = data?.segments;
+
   const navigate = useNavigate();
   const { setError, clearError } = useError();
 

--- a/src/components/NamespaceProvider.tsx
+++ b/src/components/NamespaceProvider.tsx
@@ -1,0 +1,45 @@
+import { createContext, useEffect, useState } from 'react';
+import { getNamespace } from '~/data/api';
+import { INamespace } from '~/types/Namespace';
+
+type PartialNamespace = Pick<INamespace, 'name' | 'key'>;
+
+interface NamespaceContextType {
+  currentNamespace: PartialNamespace;
+  setCurrentNamespace: (namespace: PartialNamespace) => void;
+}
+
+export const NamespaceContext = createContext({
+  currentNamespace: {} as PartialNamespace,
+  setCurrentNamespace: (_namespace: PartialNamespace) => {}
+} as NamespaceContextType);
+
+export default function NamespaceProvider({
+  children
+}: {
+  children: React.ReactNode;
+}) {
+  const [currentNamespace, setCurrentNamespace] = useState<PartialNamespace>({
+    name: '',
+    key: ''
+  });
+
+  useEffect(() => {
+    if (currentNamespace.key === '') {
+      getNamespace('default').then((namespace) => {
+        setCurrentNamespace(namespace);
+      });
+    }
+  }, [currentNamespace.key]);
+
+  return (
+    <NamespaceContext.Provider
+      value={{
+        currentNamespace,
+        setCurrentNamespace
+      }}
+    >
+      {children}
+    </NamespaceContext.Provider>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -3,12 +3,12 @@ import { XMarkIcon } from '@heroicons/react/24/outline';
 import { Fragment } from 'react';
 import { Link } from 'react-router-dom';
 import logoLight from '~/assets/logo-light.png';
-import { INamespaceBase } from '~/types/Namespace';
+import { INamespace } from '~/types/Namespace';
 import Nav from './Nav';
 import NamespaceNav from './settings/namespaces/NamespaceNav';
 
 type SidebarProps = {
-  namespaces: INamespaceBase[];
+  namespaces: INamespace[];
   sidebarOpen: boolean;
   setSidebarOpen: (sidebarOpen: boolean) => void;
 };

--- a/src/components/flags/FlagForm.tsx
+++ b/src/components/flags/FlagForm.tsx
@@ -7,6 +7,7 @@ import Input from '~/components/forms/Input';
 import Toggle from '~/components/forms/Toggle';
 import { createFlag, updateFlag } from '~/data/api';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import { useSuccess } from '~/data/hooks/success';
 import { keyValidation, requiredValidation } from '~/data/validations';
 import { IFlag, IFlagBase } from '~/types/Flag';
@@ -19,17 +20,21 @@ type FlagFormProps = {
 
 export default function FlagForm(props: FlagFormProps) {
   const { flag, flagChanged } = props;
+
   const isNew = flag === undefined;
   const submitPhrase = isNew ? 'Create' : 'Update';
+
   const navigate = useNavigate();
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
 
+  const { currentNamespace } = useNamespace();
+
   const handleSubmit = (values: IFlagBase) => {
     if (isNew) {
-      return createFlag(values);
+      return createFlag(currentNamespace?.key, values);
     }
-    return updateFlag(flag?.key, values);
+    return updateFlag(currentNamespace?.key, flag?.key, values);
   };
 
   const initialValues: IFlagBase = {

--- a/src/components/flags/VariantForm.tsx
+++ b/src/components/flags/VariantForm.tsx
@@ -10,6 +10,7 @@ import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { createVariant, updateVariant } from '~/data/api';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import { useSuccess } from '~/data/hooks/success';
 import { jsonValidation, keyValidation } from '~/data/validations';
 import { IVariant, IVariantBase } from '~/types/Variant';
@@ -23,18 +24,22 @@ type VariantFormProps = {
 
 const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
   const { setOpen, flagKey, variant, onSuccess } = props;
+
   const isNew = variant === undefined;
   const title = isNew ? 'New Variant' : 'Edit Variant';
   const submitPhrase = isNew ? 'Create' : 'Update';
+
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
 
+  const { currentNamespace } = useNamespace();
+
   const handleSubmit = async (values: IVariantBase) => {
     if (isNew) {
-      return createVariant(flagKey, values);
+      return createVariant(currentNamespace?.key, flagKey, values);
     }
 
-    return updateVariant(flagKey, variant?.id, values);
+    return updateVariant(currentNamespace?.key, flagKey, variant?.id, values);
   };
 
   return (

--- a/src/components/forms/Listbox.tsx
+++ b/src/components/forms/Listbox.tsx
@@ -8,8 +8,8 @@ type ListBoxProps<T extends ISelectable> = {
   name: string;
   placeholder?: string;
   values?: T[];
-  selected: T | null;
-  setSelected?: (v: T | null) => void;
+  selected: T;
+  setSelected?: (v: T) => void;
   disabled?: boolean;
   className?: string;
 };
@@ -29,7 +29,8 @@ export default function Listbox<T extends ISelectable>(props: ListBoxProps<T>) {
       name={name}
       className={className}
       value={selected}
-      onChange={(v: T | null) => {
+      by="key"
+      onChange={(v: T) => {
         setSelected && setSelected(v);
       }}
       disabled={disabled}

--- a/src/components/rules/EditRuleForm.tsx
+++ b/src/components/rules/EditRuleForm.tsx
@@ -9,6 +9,7 @@ import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { updateDistribution } from '~/data/api';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import { useSuccess } from '~/data/hooks/success';
 import { IEvaluatable, IRollout } from '~/types/Evaluatable';
 import { ISegment } from '~/types/Segment';
@@ -47,8 +48,11 @@ type SelectableVariant = IVariant & ISelectable;
 
 export default function EditRuleForm(props: RuleFormProps) {
   const { setOpen, rule, onSuccess } = props;
+
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
+
+  const { currentNamespace } = useNamespace();
 
   const [distributionsValid, setDistributionsValid] = useState<boolean>(true);
 
@@ -78,6 +82,7 @@ export default function EditRuleForm(props: RuleFormProps) {
           found.distribution.rollout !== rollout.distribution.rollout
         ) {
           return updateDistribution(
+            currentNamespace?.key,
             rule.flag.key,
             rule.id,
             rollout.distribution.id,

--- a/src/components/rules/RuleForm.tsx
+++ b/src/components/rules/RuleForm.tsx
@@ -10,6 +10,7 @@ import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { createDistribution, createRule } from '~/data/api';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import { useSuccess } from '~/data/hooks/success';
 import { keyValidation } from '~/data/validations';
 import { IDistributionVariant } from '~/types/Distribution';
@@ -69,8 +70,12 @@ type SelectableSegment = ISegment & ISelectable;
 
 export default function RuleForm(props: RuleFormProps) {
   const { setOpen, rulesChanged, flag, rank, segments } = props;
+
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
+
+  const { currentNamespace } = useNamespace();
+
   const [distributionsValid, setDistributionsValid] = useState<boolean>(true);
 
   const [ruleType, setRuleType] = useState('single');
@@ -103,7 +108,7 @@ export default function RuleForm(props: RuleFormProps) {
       throw new Error('No segment selected');
     }
 
-    const rule = await createRule(flag.key, {
+    const rule = await createRule(currentNamespace?.key, flag.key, {
       flagKey: flag.key,
       segmentKey: selectedSegment.key,
       rank
@@ -111,7 +116,7 @@ export default function RuleForm(props: RuleFormProps) {
 
     if (ruleType === 'multi') {
       const distPromises = distributions?.map((dist: IDistributionVariant) =>
-        createDistribution(flag.key, rule.id, {
+        createDistribution(currentNamespace?.key, flag.key, rule.id, {
           variantId: dist.variantId,
           rollout: dist.rollout
         })
@@ -121,7 +126,7 @@ export default function RuleForm(props: RuleFormProps) {
       if (selectedVariant) {
         // we allow creating rules without variants
 
-        await createDistribution(flag.key, rule.id, {
+        await createDistribution(currentNamespace?.key, flag.key, rule.id, {
           variantId: selectedVariant.id,
           rollout: 100
         });

--- a/src/components/segments/ConstraintForm.tsx
+++ b/src/components/segments/ConstraintForm.tsx
@@ -10,6 +10,7 @@ import Loading from '~/components/Loading';
 import MoreInfo from '~/components/MoreInfo';
 import { createConstraint, updateConstraint } from '~/data/api';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import { useSuccess } from '~/data/hooks/success';
 import { requiredValidation } from '~/data/validations';
 import {
@@ -134,12 +135,15 @@ type ConstraintFormProps = {
 
 const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
   const { setOpen, segmentKey, constraint, onSuccess } = props;
-  const { setError, clearError } = useError();
-  const { setSuccess } = useSuccess();
 
   const isNew = constraint === undefined;
   const submitPhrase = isNew ? 'Create' : 'Update';
   const title = isNew ? 'New Constraint' : 'Edit Constraint';
+
+  const { setError, clearError } = useError();
+  const { setSuccess } = useSuccess();
+
+  const { currentNamespace } = useNamespace();
 
   const initialValues: IConstraintBase = {
     property: constraint?.property || '',
@@ -150,9 +154,14 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
 
   const handleSubmit = async (values: IConstraintBase) => {
     if (isNew) {
-      return createConstraint(segmentKey, values);
+      return createConstraint(currentNamespace?.key, segmentKey, values);
     }
-    return updateConstraint(segmentKey, constraint?.id, values);
+    return updateConstraint(
+      currentNamespace?.key,
+      segmentKey,
+      constraint?.id,
+      values
+    );
   };
 
   return (

--- a/src/components/segments/SegmentForm.tsx
+++ b/src/components/segments/SegmentForm.tsx
@@ -6,6 +6,7 @@ import Input from '~/components/forms/Input';
 import Loading from '~/components/Loading';
 import { createSegment, updateSegment } from '~/data/api';
 import { useError } from '~/data/hooks/error';
+import useNamespace from '~/data/hooks/namespace';
 import { useSuccess } from '~/data/hooks/success';
 import { keyValidation, requiredValidation } from '~/data/validations';
 import { ISegment, ISegmentBase, SegmentMatchType } from '~/types/Segment';
@@ -31,17 +32,21 @@ type SegmentFormProps = {
 
 export default function SegmentForm(props: SegmentFormProps) {
   const { segment, segmentChanged } = props;
+
   const isNew = segment === undefined;
   const submitPhrase = isNew ? 'Create' : 'Update';
+
   const navigate = useNavigate();
   const { setError, clearError } = useError();
   const { setSuccess } = useSuccess();
 
+  const { currentNamespace } = useNamespace();
+
   const handleSubmit = (values: ISegmentBase) => {
     if (isNew) {
-      return createSegment(values);
+      return createSegment(currentNamespace?.key, values);
     }
-    return updateSegment(segment?.key, values);
+    return updateSegment(currentNamespace?.key, segment?.key, values);
   };
 
   const initialValues: ISegmentBase = {

--- a/src/components/settings/namespaces/NamespaceNav.tsx
+++ b/src/components/settings/namespaces/NamespaceNav.tsx
@@ -1,19 +1,18 @@
-import { useState } from 'react';
 import Listbox, { ISelectable } from '~/components/forms/Listbox';
-import { INamespaceBase } from '~/types/Namespace';
+import useNamespace from '~/data/hooks/namespace';
+import { INamespace } from '~/types/Namespace';
 
-type SelectableNamespace = INamespaceBase & ISelectable;
+type SelectableNamespace = Pick<INamespace, 'key' | 'name'> & ISelectable;
 
 type NamespaceNavProps = {
-  namespaces: INamespaceBase[];
+  namespaces: INamespace[];
   className?: string;
 };
 
 export default function NamespaceNav(props: NamespaceNavProps) {
   const { namespaces, className } = props;
 
-  const [selectedNamespace, setSelectedNamespace] =
-    useState<SelectableNamespace | null>(null);
+  const { currentNamespace, setCurrentNamespace } = useNamespace();
 
   return (
     <Listbox<SelectableNamespace>
@@ -24,8 +23,11 @@ export default function NamespaceNav(props: NamespaceNavProps) {
         ...n,
         displayValue: n.name
       }))}
-      selected={selectedNamespace}
-      setSelected={setSelectedNamespace}
+      selected={{
+        ...currentNamespace,
+        displayValue: currentNamespace?.name || ''
+      }}
+      setSelected={setCurrentNamespace}
     />
   );
 }

--- a/src/data/api.ts
+++ b/src/data/api.ts
@@ -31,7 +31,7 @@ function setCsrf(req: any) {
   return req;
 }
 
-async function request(method: string, uri: string, body?: any) {
+export async function request(method: string, uri: string, body?: any) {
   const req = setCsrf({
     method,
     headers: {
@@ -131,41 +131,57 @@ export async function deleteNamespace(key: string) {
 
 //
 // flags
-export async function listFlags() {
-  return get('/flags');
+export async function listFlags(namespaceKey: string) {
+  return get(`/namespaces/${namespaceKey}/flags`);
 }
 
-export async function getFlag(key: string) {
-  return get(`/flags/${key}`);
+export async function getFlag(namespaceKey: string, key: string) {
+  return get(`/namespaces/${namespaceKey}/flags/${key}`);
 }
 
-export async function createFlag(values: IFlagBase) {
-  return post('/flags', values);
+export async function createFlag(namespaceKey: string, values: IFlagBase) {
+  return post(`/namespaces/${namespaceKey}/flags`, values);
 }
 
-export async function updateFlag(key: string, values: IFlagBase) {
-  return put(`/flags/${key}`, values);
+export async function updateFlag(
+  namespaceKey: string,
+  key: string,
+  values: IFlagBase
+) {
+  return put(`/namespaces/${namespaceKey}/flags/${key}`, values);
 }
 
-export async function deleteFlag(key: string) {
-  return del(`/flags/${key}`);
+export async function deleteFlag(namespaceKey: string, key: string) {
+  return del(`/namespaces/${namespaceKey}/flags/${key}`);
 }
 
 //
 // rules
-export async function listRules(flagKey: string) {
-  return get(`/flags/${flagKey}/rules`);
+export async function listRules(namespaceKey: string, flagKey: string) {
+  return get(`/namespaces/${namespaceKey}/flags/${flagKey}/rules`);
 }
 
-export async function createRule(flagKey: string, values: IRuleBase) {
-  return post(`/flags/${flagKey}/rules`, values);
+export async function createRule(
+  namespaceKey: string,
+  flagKey: string,
+  values: IRuleBase
+) {
+  return post(`/namespaces/${namespaceKey}/flags/${flagKey}/rules`, values);
 }
 
-export async function deleteRule(flagKey: string, ruleId: string) {
-  return del(`/flags/${flagKey}/rules/${ruleId}`);
+export async function deleteRule(
+  namespaceKey: string,
+  flagKey: string,
+  ruleId: string
+) {
+  return del(`/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}`);
 }
 
-export async function orderRules(flagKey: string, ruleIds: string[]) {
+export async function orderRules(
+  namespaceKey: string,
+  flagKey: string,
+  ruleIds: string[]
+) {
   const req = setCsrf({
     method: 'PUT',
     headers: {
@@ -176,7 +192,10 @@ export async function orderRules(flagKey: string, ruleIds: string[]) {
     })
   });
 
-  const res = await fetch(`${apiURL}/flags/${flagKey}/rules/order`, req);
+  const res = await fetch(
+    `${apiURL}/namespaces/${namespaceKey}/flags/${flagKey}/rules/order`,
+    req
+  );
   if (!res.ok) {
     const err = await res.json();
     throw new Error(err.message);
@@ -185,93 +204,135 @@ export async function orderRules(flagKey: string, ruleIds: string[]) {
 }
 
 export async function createDistribution(
+  namespaceKey: string,
   flagKey: string,
   ruleId: string,
   values: IDistributionBase
 ) {
-  return post(`/flags/${flagKey}/rules/${ruleId}/distributions`, values);
+  return post(
+    `/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}/distributions`,
+    values
+  );
 }
 
 export async function updateDistribution(
+  namespaceKey: string,
   flagKey: string,
   ruleId: string,
   distributionId: string,
   values: IDistributionBase
 ) {
   return put(
-    `/flags/${flagKey}/rules/${ruleId}/distributions/${distributionId}`,
+    `/namespaces/${namespaceKey}/flags/${flagKey}/rules/${ruleId}/distributions/${distributionId}`,
     values
   );
 }
 
 //
 // variants
-export async function createVariant(flagKey: string, values: IVariantBase) {
-  return post(`/flags/${flagKey}/variants`, values);
+export async function createVariant(
+  namespaceKey: string,
+  flagKey: string,
+  values: IVariantBase
+) {
+  return post(`/namespaces/${namespaceKey}/flags/${flagKey}/variants`, values);
 }
 
 export async function updateVariant(
+  namespaceKey: string,
   flagKey: string,
   variantId: string,
   values: IVariantBase
 ) {
-  return put(`/flags/${flagKey}/variants/${variantId}`, values);
+  return put(
+    `/namespaces/${namespaceKey}/flags/${flagKey}/variants/${variantId}`,
+    values
+  );
 }
 
-export async function deleteVariant(flagKey: string, variantId: string) {
-  return del(`/flags/${flagKey}/variants/${variantId}`);
+export async function deleteVariant(
+  namespaceKey: string,
+  flagKey: string,
+  variantId: string
+) {
+  return del(
+    `/namespaces/${namespaceKey}/flags/${flagKey}/variants/${variantId}`
+  );
 }
 
 //
 // segments
-export async function listSegments() {
-  return get('/segments');
+export async function listSegments(namespaceKey: string) {
+  return get(`/namespaces/${namespaceKey}/segments`);
 }
 
-export async function getSegment(key: string) {
-  return get(`/segments/${key}`);
+export async function getSegment(namespaceKey: string, key: string) {
+  return get(`/namespaces/${namespaceKey}/segments/${key}`);
 }
 
-export async function createSegment(values: ISegmentBase) {
-  return post('/segments', values);
+export async function createSegment(
+  namespaceKey: string,
+  values: ISegmentBase
+) {
+  return post(`/namespaces/${namespaceKey}/segments`, values);
 }
 
-export async function updateSegment(key: string, values: ISegmentBase) {
-  return put(`/segments/${key}`, values);
+export async function updateSegment(
+  namespaceKey: string,
+  key: string,
+  values: ISegmentBase
+) {
+  return put(`/namespaces/${namespaceKey}/segments/${key}`, values);
 }
 
-export async function deleteSegment(key: string) {
-  return del(`/segments/${key}`);
+export async function deleteSegment(namespaceKey: string, key: string) {
+  return del(`/namespaces/${namespaceKey}/segments/${key}`);
 }
 
 //
 // constraints
 export async function createConstraint(
+  namespaceKey: string,
   segmentKey: string,
   values: IConstraintBase
 ) {
-  return post(`/segments/${segmentKey}/constraints`, values);
+  return post(
+    `/namespaces/${namespaceKey}/segments/${segmentKey}/constraints`,
+    values
+  );
 }
 
 export async function updateConstraint(
+  namespaceKey: string,
   segmentKey: string,
   constraintId: string,
   values: IConstraintBase
 ) {
-  return put(`/segments/${segmentKey}/constraints/${constraintId}`, values);
+  return put(
+    `/namespaces/${namespaceKey}/segments/${segmentKey}/constraints/${constraintId}`,
+    values
+  );
 }
 
 export async function deleteConstraint(
+  namespaceKey: string,
   segmentKey: string,
   constraintId: string
 ) {
-  return del(`/segments/${segmentKey}/constraints/${constraintId}`);
+  return del(
+    `/namespaces/${namespaceKey}/segments/${segmentKey}/constraints/${constraintId}`
+  );
 }
 
 //
 // evaluate
-export async function evaluate(flagKey: string, values: any) {
+export async function evaluate(
+  namespaceKey: string,
+  flagKey: string,
+  values: any
+) {
   const body = {
+    namespaceKey,
     flagKey,
     ...values
   };

--- a/src/data/hooks/namespace.ts
+++ b/src/data/hooks/namespace.ts
@@ -1,0 +1,8 @@
+import { useContext } from 'react';
+import { NamespaceContext } from '~/components/NamespaceProvider';
+
+export default function useNamespace() {
+  const { currentNamespace, setCurrentNamespace } =
+    useContext(NamespaceContext);
+  return { currentNamespace, setCurrentNamespace };
+}


### PR DESCRIPTION
Fixes: FLI-224

- Wires up namespaces switcher to API
- Adds `namespaceKey` to all API funcs that require it
- Adds `useNamespace` hook to get/set current namespace for API calls
- Removes router loader functionality for Flag and Segment view page in place of simple `useEffect` hooks because I wasn't able to access the `currentNamespace` hook/ context value in the react router loader funcs

**Note**: there is currently a bug where if you delete a namespace from the settings page it still shows in the dropdown until you do a hard page refresh. will need to figure this out / potentially fix in another PR

**Needs Tests**: I will also add some Playwright tests in another PR as well, as this one is rather large

Also I spoke with @darinmclain about us potentially refactoring to use something like Redux in the future to maintain this global state, but I think this is good enough for now