### PR TITLE
Fix err msgs

### DIFF
--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -16,7 +16,7 @@ function InnerLayout() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [namespaces, setNamespaces] = useState<INamespace[]>([]);
 
-  const { setError, clearError } = useError();
+  const { setError } = useError();
 
   useEffect(() => {
     if (!session) return;
@@ -24,12 +24,11 @@ function InnerLayout() {
     listNamespaces()
       .then((data) => {
         setNamespaces(data.namespaces);
-        clearError();
       })
       .catch((err) => {
         setError(err);
       });
-  }, [clearError, session, setError]);
+  }, [session, setError]);
 
   if (!session) {
     return <Navigate to="/login" />;

--- a/src/app/flags/EditFlag.tsx
+++ b/src/app/flags/EditFlag.tsx
@@ -70,7 +70,6 @@ export default function EditFlag() {
               ) // TODO: Determine impact of blank ID param
           }
           onSuccess={() => {
-            setShowDeleteVariantModal(false);
             onFlagChange();
           }}
         />

--- a/src/app/flags/Evaluation.tsx
+++ b/src/app/flags/Evaluation.tsx
@@ -194,7 +194,6 @@ export default function Evaluation() {
           }
           onSuccess={() => {
             incrementRulesVersion();
-            setShowDeleteRuleModal(false);
           }}
         />
       </Modal>

--- a/src/app/flags/Flag.tsx
+++ b/src/app/flags/Flag.tsx
@@ -71,7 +71,6 @@ export default function Flag() {
           setOpen={setShowDeleteFlagModal}
           handleDelete={() => deleteFlag(currentNamespace?.key, flag.key)}
           onSuccess={() => {
-            setShowDeleteFlagModal(false);
             navigate('/');
           }}
         />

--- a/src/app/segments/Segment.tsx
+++ b/src/app/segments/Segment.tsx
@@ -115,7 +115,6 @@ export default function Segment() {
           }
           onSuccess={() => {
             incrementSegmentVersion();
-            setShowDeleteConstraintModal(false);
           }}
         />
       </Modal>
@@ -134,7 +133,6 @@ export default function Segment() {
           setOpen={setShowDeleteSegmentModal}
           handleDelete={() => deleteSegment(currentNamespace?.key, segment.key)}
           onSuccess={() => {
-            setShowDeleteSegmentModal(false);
             navigate('/segments');
           }}
         />

--- a/src/app/settings/namespaces/Namespaces.tsx
+++ b/src/app/settings/namespaces/Namespaces.tsx
@@ -84,8 +84,6 @@ export default function Namespaces(): JSX.Element {
             () => deleteNamespace(deletingNamespace?.key ?? '') // TODO: Determine impact of blank ID param
           }
           onSuccess={() => {
-            setShowDeleteNamespaceModal(false);
-            setDeletingNamespace(null);
             incrementNamespacesVersion();
           }}
         />

--- a/src/app/settings/tokens/Tokens.tsx
+++ b/src/app/settings/tokens/Tokens.tsx
@@ -145,7 +145,6 @@ export default function Tokens() {
           handleDelete={() => deleteToken(deletingToken?.id ?? '')} // TODO: Determine impact of blank ID param
           onSuccess={() => {
             incrementTokensVersion();
-            setShowDeleteTokenModal(false);
           }}
         />
       </Modal>

--- a/src/components/DeletePanel.tsx
+++ b/src/components/DeletePanel.tsx
@@ -52,6 +52,9 @@ export default function DeletePanel(props: DeletePanelProps) {
               })
               .catch((err) => {
                 setError(err);
+              })
+              .finally(() => {
+                setOpen(false);
               });
           }}
         >

--- a/src/components/flags/FlagForm.tsx
+++ b/src/components/flags/FlagForm.tsx
@@ -48,7 +48,7 @@ export default function FlagForm(props: FlagFormProps) {
     <Formik
       enableReinitialize
       initialValues={initialValues}
-      onSubmit={(values) => {
+      onSubmit={(values, { setSubmitting }) => {
         handleSubmit(values)
           .then(() => {
             clearError();
@@ -63,8 +63,10 @@ export default function FlagForm(props: FlagFormProps) {
             flagChanged && flagChanged();
           })
           .catch((err) => {
-            console.log(err);
             setError(err);
+          })
+          .finally(() => {
+            setSubmitting(false);
           });
       }}
       validationSchema={Yup.object({

--- a/src/components/flags/VariantForm.tsx
+++ b/src/components/flags/VariantForm.tsx
@@ -50,7 +50,7 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
         description: variant?.description || '',
         attachment: variant?.attachment || ''
       }}
-      onSubmit={(values) => {
+      onSubmit={(values, { setSubmitting }) => {
         handleSubmit(values)
           .then(() => {
             clearError();
@@ -61,6 +61,9 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
           })
           .catch((err) => {
             setError(err);
+          })
+          .finally(() => {
+            setSubmitting(false);
           });
       }}
       validationSchema={Yup.object({

--- a/src/components/rules/EditRuleForm.tsx
+++ b/src/components/rules/EditRuleForm.tsx
@@ -100,7 +100,7 @@ export default function EditRuleForm(props: RuleFormProps) {
       initialValues={{
         segmentKey: rule.segment.key || ''
       }}
-      onSubmit={() => {
+      onSubmit={(_, { setSubmitting }) => {
         handleSubmit()
           ?.then(() => {
             clearError();
@@ -109,10 +109,13 @@ export default function EditRuleForm(props: RuleFormProps) {
           })
           .catch((err) => {
             setError(err);
+          })
+          .finally(() => {
+            setSubmitting(false);
           });
       }}
     >
-      {(_formik) => {
+      {(formik) => {
         return (
           <Form className="flex h-full flex-col overflow-y-scroll bg-white shadow-xl">
             <div className="flex-1">
@@ -312,10 +315,10 @@ export default function EditRuleForm(props: RuleFormProps) {
                 <Button
                   primary
                   type="submit"
-                  disabled={!(distributionsValid && !_formik.isSubmitting)}
+                  disabled={!(distributionsValid && !formik.isSubmitting)}
                   className="min-w-[80px]"
                 >
-                  {_formik.isSubmitting ? <Loading isPrimary /> : 'Update'}
+                  {formik.isSubmitting ? <Loading isPrimary /> : 'Update'}
                 </Button>
               </div>
             </div>

--- a/src/components/rules/RuleForm.tsx
+++ b/src/components/rules/RuleForm.tsx
@@ -132,11 +132,6 @@ export default function RuleForm(props: RuleFormProps) {
         });
       }
     }
-
-    rulesChanged();
-    clearError();
-    setSuccess('Successfully created rule');
-    setOpen(false);
   };
 
   return (
@@ -147,10 +142,20 @@ export default function RuleForm(props: RuleFormProps) {
       validationSchema={Yup.object({
         segmentKey: keyValidation
       })}
-      onSubmit={() => {
-        handleSubmit().catch((err) => {
-          setError(err);
-        });
+      onSubmit={(_, { setSubmitting }) => {
+        handleSubmit()
+          .then(() => {
+            rulesChanged();
+            clearError();
+            setSuccess('Successfully created rule');
+            setOpen(false);
+          })
+          .catch((err) => {
+            setError(err);
+          })
+          .finally(() => {
+            setSubmitting(false);
+          });
       }}
     >
       {(formik) => {

--- a/src/components/segments/ConstraintForm.tsx
+++ b/src/components/segments/ConstraintForm.tsx
@@ -168,7 +168,7 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
     <Formik
       initialValues={initialValues}
       enableReinitialize={true}
-      onSubmit={(values) => {
+      onSubmit={(values, { setSubmitting }) => {
         handleSubmit(values)
           .then(() => {
             clearError();
@@ -179,6 +179,9 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
           })
           .catch((err) => {
             setError(err);
+          })
+          .finally(() => {
+            setSubmitting(false);
           });
       }}
       validationSchema={Yup.object({

--- a/src/components/segments/SegmentForm.tsx
+++ b/src/components/segments/SegmentForm.tsx
@@ -60,7 +60,7 @@ export default function SegmentForm(props: SegmentFormProps) {
     <Formik
       enableReinitialize
       initialValues={initialValues}
-      onSubmit={(values) => {
+      onSubmit={(values, { setSubmitting }) => {
         handleSubmit(values)
           .then(() => {
             clearError();
@@ -76,6 +76,9 @@ export default function SegmentForm(props: SegmentFormProps) {
           })
           .catch((err) => {
             setError(err);
+          })
+          .finally(() => {
+            setSubmitting(false);
           });
       }}
       validationSchema={Yup.object({

--- a/src/components/settings/namespaces/NamespaceForm.tsx
+++ b/src/components/settings/namespaces/NamespaceForm.tsx
@@ -43,7 +43,7 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
         name: namespace?.name || '',
         description: namespace?.description || ''
       }}
-      onSubmit={(values) => {
+      onSubmit={(values, { setSubmitting }) => {
         handleSubmit(values)
           .then(() => {
             clearError();
@@ -54,6 +54,9 @@ const NamespaceForm = forwardRef((props: NamespaceFormProps, ref: any) => {
           })
           .catch((err) => {
             setError(err);
+          })
+          .finally(() => {
+            setSubmitting(false);
           });
       }}
       validationSchema={Yup.object({

--- a/src/components/settings/tokens/TokenForm.tsx
+++ b/src/components/settings/tokens/TokenForm.tsx
@@ -40,7 +40,7 @@ const TokenForm = forwardRef((props: TokenFormProps, ref: any) => {
         name: requiredValidation,
         description: requiredValidation
       })}
-      onSubmit={(values) => {
+      onSubmit={(values, { setSubmitting }) => {
         let token: IAuthTokenBase = {
           name: values.name,
           description: values.description
@@ -58,8 +58,10 @@ const TokenForm = forwardRef((props: TokenFormProps, ref: any) => {
             clearError();
           })
           .catch((err) => {
-            console.log(err);
             setError(err.message);
+          })
+          .finally(() => {
+            setSubmitting(false);
           });
       }}
     >


### PR DESCRIPTION
![Kapture 2023-03-29 at 11 33 21](https://user-images.githubusercontent.com/209477/228591386-16ba8c2c-6ab9-4c4f-85f2-5e98a74eb2f6.gif)

Fixes a couple of issues relating to errors/deleting/submitting:

1. sets formik `isSubmitting` to false after all submits to stop the loading spinner button, even on errors
2. the useEffect hook that was loading `namespaces` was clearing out all error messages automatically, which meant error messages were being shown for a split second then removed.
3. errors occurring on a delete were being hidden behind the modal. This now closes the modal even on errors and removes the requirement for the user of the ErrorPanel to call `setOpen` by doing it in a finally block in the component