### PR TITLE
fix: issue where namespace picker doesnt refresh

### DIFF
--- a/src/app/Layout.tsx
+++ b/src/app/Layout.tsx
@@ -14,6 +14,9 @@ import { INamespace } from '~/types/Namespace';
 function InnerLayout() {
   const { session } = useSession();
   const [sidebarOpen, setSidebarOpen] = useState(false);
+
+  // TODO: replace with a proper state management solution like Redux
+  // instead of passing around via context
   const [namespaces, setNamespaces] = useState<INamespace[]>([]);
 
   const { setError } = useError();
@@ -46,7 +49,7 @@ function InnerLayout() {
 
         <main className="flex px-6 py-10">
           <div className="w-full overflow-x-auto px-4 sm:px-6 lg:px-8">
-            <Outlet />
+            <Outlet context={{ namespaces, setNamespaces }} />
           </div>
         </main>
         <Footer />

--- a/src/app/settings/Settings.tsx
+++ b/src/app/settings/Settings.tsx
@@ -1,4 +1,4 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useOutletContext } from 'react-router-dom';
 import TabBar from '~/components/TabBar';
 
 export default function Settings() {
@@ -23,7 +23,7 @@ export default function Settings() {
         </div>
       </div>
       <TabBar tabs={tabs} />
-      <Outlet />
+      <Outlet context={useOutletContext()} />
     </>
   );
 }

--- a/src/app/settings/namespaces/Namespaces.tsx
+++ b/src/app/settings/namespaces/Namespaces.tsx
@@ -1,5 +1,6 @@
 import { PlusIcon } from '@heroicons/react/24/outline';
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { useOutletContext } from 'react-router-dom';
 import DeletePanel from '~/components/DeletePanel';
 import EmptyState from '~/components/EmptyState';
 import Button from '~/components/forms/Button';
@@ -8,10 +9,17 @@ import NamespaceForm from '~/components/settings/namespaces/NamespaceForm';
 import NamespaceTable from '~/components/settings/namespaces/NamespaceTable';
 import Slideover from '~/components/Slideover';
 import { deleteNamespace, listNamespaces } from '~/data/api';
+import { useError } from '~/data/hooks/error';
 import { INamespace, INamespaceList } from '~/types/Namespace';
 
+type NamespaceContextType = {
+  namespaces: INamespace[];
+  setNamespaces: (namespaces: INamespace[]) => void;
+};
+
 export default function Namespaces(): JSX.Element {
-  const [namespaces, setNamespaces] = useState<INamespace[]>([]);
+  const { namespaces, setNamespaces } =
+    useOutletContext<NamespaceContextType>();
 
   const [showNamespaceForm, setShowNamespaceForm] = useState<boolean>(false);
 
@@ -27,11 +35,17 @@ export default function Namespaces(): JSX.Element {
 
   const [namespacesVersion, setNamespacesVersion] = useState(0);
 
+  const { setError } = useError();
+
   const fetchNamespaces = useCallback(() => {
-    listNamespaces().then((resp: INamespaceList) => {
-      setNamespaces(resp.namespaces);
-    });
-  }, []);
+    listNamespaces()
+      .then((resp: INamespaceList) => {
+        setNamespaces(resp.namespaces);
+      })
+      .catch((err) => {
+        setError(err);
+      });
+  }, [setError, setNamespaces]);
 
   const incrementNamespacesVersion = () => {
     setNamespacesVersion(namespacesVersion + 1);


### PR DESCRIPTION
Fixes: FLI-293

Fixes issue where namespace picker was not being refreshed with new/deleted namespaces

It accomplishes this by pulling the `namespaces` state up and using [router context](https://reactrouter.com/en/main/hooks/use-outlet-context) to pass it down to the Namespaces component

In the future, we'd like to use a proper global state solution like Redux or MobX.. but we arent ready to bite that off yet