### PR TITLE
fix: reset console on namespace change

### DIFF
--- a/src/app/NotFoundLayout.tsx
+++ b/src/app/NotFoundLayout.tsx
@@ -67,7 +67,7 @@ export default function NotFoundLayout() {
             </h2>
             <ul
               role="list"
-              className="mt-4 divide-y divide-gray-200 border-t border-b border-gray-200"
+              className="mt-4 divide-y divide-gray-200 border-b border-t border-gray-200"
             >
               {links.map((link, linkIdx) => (
                 <li

--- a/src/app/auth/Login.tsx
+++ b/src/app/auth/Login.tsx
@@ -121,13 +121,13 @@ export default function Login() {
             </div>
 
             <div className="mt-8 sm:mx-auto sm:w-full sm:max-w-sm">
-              <div className="py-8 px-4 sm:px-10">
+              <div className="px-4 py-8 sm:px-10">
                 <div className="mt-6 flex flex-col space-y-5">
                   {providers.map((provider) => (
                     <div key={provider.name}>
                       <a
                         href="#"
-                        className="inline-flex w-full justify-center rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-500 shadow-sm hover:text-violet-500 hover:shadow-violet-300"
+                        className="inline-flex w-full justify-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-500 shadow-sm hover:text-violet-500 hover:shadow-violet-300"
                         onClick={(e) => {
                           e.preventDefault();
                           authorize(provider.authorize_url);

--- a/src/app/console/Console.tsx
+++ b/src/app/console/Console.tsx
@@ -1,4 +1,4 @@
-import { Form, Formik } from 'formik';
+import { Form, Formik, useFormikContext } from 'formik';
 import hljs from 'highlight.js';
 import javascript from 'highlight.js/lib/languages/json';
 import 'highlight.js/styles/tokyo-night-dark.css';
@@ -21,10 +21,21 @@ import {
 } from '~/data/validations';
 import { IConsole } from '~/types/Console';
 import { IFlag, IFlagList } from '~/types/Flag';
+import { INamespace } from '~/types/Namespace';
 
 hljs.registerLanguage('json', javascript);
 
 type SelectableFlag = IFlag & ISelectable;
+
+function ResetOnNamespaceChange({ namespace }: { namespace: INamespace }) {
+  const { resetForm } = useFormikContext();
+
+  useEffect(() => {
+    resetForm();
+  }, [namespace, resetForm]);
+
+  return null;
+}
 
 export default function Console() {
   const [flags, setFlags] = useState<SelectableFlag[]>([]);
@@ -38,7 +49,7 @@ export default function Console() {
 
   const loadData = useCallback(async () => {
     const initialFlagList = (await listFlags(
-      currentNamespace?.key
+      currentNamespace.key
     )) as IFlagList;
     const { flags } = initialFlagList;
 
@@ -54,7 +65,7 @@ export default function Console() {
         };
       })
     );
-  }, [currentNamespace?.key]);
+  }, [currentNamespace.key]);
 
   const handleSubmit = (values: IConsole) => {
     const { flagKey, entityId, context } = values;
@@ -66,7 +77,7 @@ export default function Console() {
       context: parsed
     };
 
-    evaluate(currentNamespace?.key, flagKey, rest)
+    evaluate(currentNamespace.key, flagKey, rest)
       .then((resp) => {
         setResponse(JSON.stringify(resp, null, 2));
       })
@@ -195,6 +206,7 @@ export default function Console() {
                         </Button>
                       </div>
                     </div>
+                    <ResetOnNamespaceChange namespace={currentNamespace} />
                   </Form>
                 )}
               </Formik>

--- a/src/app/flags/EditFlag.tsx
+++ b/src/app/flags/EditFlag.tsx
@@ -64,7 +64,7 @@ export default function EditFlag() {
           handleDelete={
             () =>
               deleteVariant(
-                currentNamespace?.key,
+                currentNamespace.key,
                 flag.key,
                 deletingVariant?.id ?? ''
               ) // TODO: Determine impact of blank ID param
@@ -108,7 +108,7 @@ export default function EditFlag() {
               </p>
             </div>
             {flag.variants && flag.variants.length > 0 && (
-              <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+              <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
                 <Button
                   primary
                   type="button"

--- a/src/app/flags/Evaluation.tsx
+++ b/src/app/flags/Evaluation.tsx
@@ -62,13 +62,13 @@ export default function Evaluation() {
 
   const loadData = useCallback(async () => {
     const segmentList = (await listSegments(
-      currentNamespace?.key
+      currentNamespace.key
     )) as ISegmentList;
     const { segments } = segmentList;
     setSegments(segments);
 
     const ruleList = (await listRules(
-      currentNamespace?.key,
+      currentNamespace.key,
       flag.key
     )) as IRuleList;
 
@@ -109,7 +109,7 @@ export default function Evaluation() {
     });
 
     setRules(rules);
-  }, [currentNamespace?.key, flag]);
+  }, [currentNamespace.key, flag]);
 
   const incrementRulesVersion = () => {
     setRulesVersion(rulesVersion + 1);
@@ -124,7 +124,7 @@ export default function Evaluation() {
 
   const reorderRules = (rules: IEvaluatable[]) => {
     orderRules(
-      currentNamespace?.key,
+      currentNamespace.key,
       flag.key,
       rules.map((rule) => rule.id)
     )
@@ -190,7 +190,7 @@ export default function Evaluation() {
           panelType="Rule"
           setOpen={setShowDeleteRuleModal}
           handleDelete={() =>
-            deleteRule(currentNamespace?.key, flag.key, deletingRule?.id ?? '')
+            deleteRule(currentNamespace.key, flag.key, deletingRule?.id ?? '')
           }
           onSuccess={() => {
             incrementRulesVersion();
@@ -235,7 +235,7 @@ export default function Evaluation() {
             </p>
           </div>
           {rules && rules.length > 0 && (
-            <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+            <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
               <Button
                 primary
                 type="button"

--- a/src/app/flags/Flag.tsx
+++ b/src/app/flags/Flag.tsx
@@ -98,7 +98,7 @@ export default function Flag() {
         <div className="flex flex-none">
           <button
             type="button"
-            className="mt-5 mb-1 inline-flex items-center justify-center rounded-md border border-red-200 px-4 py-2 text-sm font-medium text-red-400 focus:outline-none enabled:hover:bg-red-50 sm:mt-0"
+            className="mb-1 mt-5 inline-flex items-center justify-center rounded-md border border-red-200 px-4 py-2 text-sm font-medium text-red-400 focus:outline-none enabled:hover:bg-red-50 sm:mt-0"
             onClick={() => setShowDeleteFlagModal(true)}
           >
             Delete

--- a/src/app/segments/Segment.tsx
+++ b/src/app/segments/Segment.tsx
@@ -49,7 +49,7 @@ export default function Segment() {
   useEffect(() => {
     if (!segmentKey) return;
 
-    getSegment(currentNamespace?.key, segmentKey)
+    getSegment(currentNamespace.key, segmentKey)
       .then((segment: ISegment) => {
         setSegment(segment);
         clearError();
@@ -57,7 +57,7 @@ export default function Segment() {
       .catch((err) => {
         setError(err);
       });
-  }, [segmentVersion, currentNamespace?.key, segmentKey, clearError, setError]);
+  }, [segmentVersion, currentNamespace.key, segmentKey, clearError, setError]);
 
   const constraintTypeToLabel = (t: string) =>
     ComparisonType[t as keyof typeof ComparisonType];
@@ -108,7 +108,7 @@ export default function Segment() {
           handleDelete={
             () =>
               deleteConstraint(
-                currentNamespace?.key,
+                currentNamespace.key,
                 segment.key,
                 deletingConstraint?.id ?? ''
               ) // TODO: Determine impact of blank ID param
@@ -160,7 +160,7 @@ export default function Segment() {
         <div className="flex flex-none">
           <button
             type="button"
-            className="mt-5 mb-1 inline-flex items-center justify-center rounded-md border border-red-200 px-4 py-2 text-sm font-medium text-red-400 focus:outline-none enabled:hover:bg-red-50 sm:mt-0"
+            className="mb-1 mt-5 inline-flex items-center justify-center rounded-md border border-red-200 px-4 py-2 text-sm font-medium text-red-400 focus:outline-none enabled:hover:bg-red-50 sm:mt-0"
             onClick={() => {
               setShowDeleteSegmentModal(true);
             }}
@@ -210,7 +210,7 @@ export default function Segment() {
                 </p>
               </div>
               {segment.constraints && segment.constraints.length > 0 && (
-                <div className="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+                <div className="mt-4 sm:ml-16 sm:mt-0 sm:flex-none">
                   <Button
                     primary
                     type="button"

--- a/src/components/DeletePanel.tsx
+++ b/src/components/DeletePanel.tsx
@@ -28,7 +28,7 @@ export default function DeletePanel(props: DeletePanelProps) {
             aria-hidden="true"
           />
         </div>
-        <div className="mt-3 text-center sm:mt-0 sm:ml-4 sm:text-left">
+        <div className="mt-3 text-center sm:ml-4 sm:mt-0 sm:text-left">
           <Dialog.Title
             as="h3"
             className="text-lg font-medium leading-6 text-gray-900"

--- a/src/components/Modal.tsx
+++ b/src/components/Modal.tsx
@@ -36,7 +36,7 @@ export default function Modal(props: ModalProps) {
               leaveFrom="opacity-100 translate-y-0 sm:scale-100"
               leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
             >
-              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+              <Dialog.Panel className="relative transform overflow-hidden rounded-lg bg-white px-4 pb-4 pt-5 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
                 {props.children}
               </Dialog.Panel>
             </Transition.Child>

--- a/src/components/Notifications.tsx
+++ b/src/components/Notifications.tsx
@@ -122,7 +122,7 @@ export default function Notifications(props: NotificationsProps) {
         className="without-ring relative rounded-full text-violet-100"
       >
         {newNotifications && (
-          <span className="absolute top-0 right-0 flex h-2 w-2">
+          <span className="absolute right-0 top-0 flex h-2 w-2">
             <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-white opacity-75"></span>
             <span className="relative inline-flex h-2 w-2 rounded-full bg-violet-100"></span>
           </span>

--- a/src/components/Pagination.tsx
+++ b/src/components/Pagination.tsx
@@ -84,7 +84,7 @@ export default function Pagination(props: PaginationProps) {
         {currentPage > 1 && (
           <a
             href="#"
-            className="inline-flex items-center border-t-2 border-transparent pt-4 pr-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700"
+            className="inline-flex items-center border-t-2 border-transparent pr-1 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700"
             onClick={(e) => {
               e.preventDefault();
               onPreviousPage();
@@ -112,7 +112,7 @@ export default function Pagination(props: PaginationProps) {
         {currentPage < lastPage && (
           <a
             href="#"
-            className="inline-flex items-center border-t-2 border-transparent pt-4 pl-1 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700"
+            className="inline-flex items-center border-t-2 border-transparent pl-1 pt-4 text-sm font-medium text-gray-500 hover:border-gray-300 hover:text-gray-700"
             onClick={(e) => {
               e.preventDefault();
               onNextPage();

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -45,7 +45,7 @@ export default function Sidebar(props: SidebarProps) {
               leaveFrom="translate-x-0"
               leaveTo="-translate-x-full"
             >
-              <Dialog.Panel className="relative flex w-full max-w-xs flex-1 flex-col bg-violet-300 pt-5 pb-4">
+              <Dialog.Panel className="relative flex w-full max-w-xs flex-1 flex-col bg-violet-300 pb-4 pt-5">
                 <Transition.Child
                   as={Fragment}
                   enter="ease-in-out duration-300"
@@ -55,7 +55,7 @@ export default function Sidebar(props: SidebarProps) {
                   leaveFrom="opacity-100"
                   leaveTo="opacity-0"
                 >
-                  <div className="absolute top-0 right-0 -mr-12 pt-2">
+                  <div className="absolute right-0 top-0 -mr-12 pt-2">
                     <button
                       type="button"
                       className="ml-1 flex h-10 w-10 items-center justify-center rounded-full focus:outline-none focus:ring-2 focus:ring-inset focus:ring-white"

--- a/src/components/flags/FlagForm.tsx
+++ b/src/components/flags/FlagForm.tsx
@@ -32,9 +32,9 @@ export default function FlagForm(props: FlagFormProps) {
 
   const handleSubmit = (values: IFlagBase) => {
     if (isNew) {
-      return createFlag(currentNamespace?.key, values);
+      return createFlag(currentNamespace.key, values);
     }
-    return updateFlag(currentNamespace?.key, flag?.key, values);
+    return updateFlag(currentNamespace.key, flag?.key, values);
   };
 
   const initialValues: IFlagBase = {

--- a/src/components/flags/FlagTable.tsx
+++ b/src/components/flags/FlagTable.tsx
@@ -159,7 +159,7 @@ export default function FlagTable(props: FlagTableProps) {
                   <th
                     key={header.id}
                     scope="col"
-                    className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900"
+                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                   >
                     <div
                       className="group inline-flex cursor-pointer"
@@ -193,7 +193,7 @@ export default function FlagTable(props: FlagTableProps) {
                   <th
                     key={header.id}
                     scope="col"
-                    className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900"
+                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                   >
                     {header.isPlaceholder
                       ? null

--- a/src/components/flags/VariantForm.tsx
+++ b/src/components/flags/VariantForm.tsx
@@ -36,10 +36,10 @@ const VariantForm = forwardRef((props: VariantFormProps, ref: any) => {
 
   const handleSubmit = async (values: IVariantBase) => {
     if (isNew) {
-      return createVariant(currentNamespace?.key, flagKey, values);
+      return createVariant(currentNamespace.key, flagKey, values);
     }
 
-    return updateVariant(currentNamespace?.key, flagKey, variant?.id, values);
+    return updateVariant(currentNamespace.key, flagKey, variant?.id, values);
   };
 
   return (

--- a/src/components/rules/EditRuleForm.tsx
+++ b/src/components/rules/EditRuleForm.tsx
@@ -82,7 +82,7 @@ export default function EditRuleForm(props: RuleFormProps) {
           found.distribution.rollout !== rollout.distribution.rollout
         ) {
           return updateDistribution(
-            currentNamespace?.key,
+            currentNamespace.key,
             rule.flag.key,
             rule.id,
             rollout.distribution.id,
@@ -262,7 +262,7 @@ export default function EditRuleForm(props: RuleFormProps) {
                         <div>
                           <label
                             htmlFor={dist.variant.key}
-                            className="block truncate text-right text-sm text-gray-600 sm:mt-px sm:pt-2 sm:pr-2"
+                            className="block truncate text-right text-sm text-gray-600 sm:mt-px sm:pr-2 sm:pt-2"
                           >
                             {dist.variant.key}
                           </label>

--- a/src/components/rules/RuleForm.tsx
+++ b/src/components/rules/RuleForm.tsx
@@ -108,7 +108,7 @@ export default function RuleForm(props: RuleFormProps) {
       throw new Error('No segment selected');
     }
 
-    const rule = await createRule(currentNamespace?.key, flag.key, {
+    const rule = await createRule(currentNamespace.key, flag.key, {
       flagKey: flag.key,
       segmentKey: selectedSegment.key,
       rank
@@ -116,7 +116,7 @@ export default function RuleForm(props: RuleFormProps) {
 
     if (ruleType === 'multi') {
       const distPromises = distributions?.map((dist: IDistributionVariant) =>
-        createDistribution(currentNamespace?.key, flag.key, rule.id, {
+        createDistribution(currentNamespace.key, flag.key, rule.id, {
           variantId: dist.variantId,
           rollout: dist.rollout
         })
@@ -126,7 +126,7 @@ export default function RuleForm(props: RuleFormProps) {
       if (selectedVariant) {
         // we allow creating rules without variants
 
-        await createDistribution(currentNamespace?.key, flag.key, rule.id, {
+        await createDistribution(currentNamespace.key, flag.key, rule.id, {
           variantId: selectedVariant.id,
           rollout: 100
         });

--- a/src/components/rules/distributions/MultiDistributionForm.tsx
+++ b/src/components/rules/distributions/MultiDistributionForm.tsx
@@ -30,7 +30,7 @@ export default function MultiDistributionFormInputs(
           <div>
             <label
               htmlFor={dist.variantKey}
-              className="block truncate text-right text-sm text-gray-600 sm:mt-px sm:pt-2 sm:pr-2"
+              className="block truncate text-right text-sm text-gray-600 sm:mt-px sm:pr-2 sm:pt-2"
             >
               {dist.variantKey}
             </label>

--- a/src/components/segments/ConstraintForm.tsx
+++ b/src/components/segments/ConstraintForm.tsx
@@ -154,10 +154,10 @@ const ConstraintForm = forwardRef((props: ConstraintFormProps, ref: any) => {
 
   const handleSubmit = async (values: IConstraintBase) => {
     if (isNew) {
-      return createConstraint(currentNamespace?.key, segmentKey, values);
+      return createConstraint(currentNamespace.key, segmentKey, values);
     }
     return updateConstraint(
-      currentNamespace?.key,
+      currentNamespace.key,
       segmentKey,
       constraint?.id,
       values

--- a/src/components/segments/SegmentForm.tsx
+++ b/src/components/segments/SegmentForm.tsx
@@ -44,9 +44,9 @@ export default function SegmentForm(props: SegmentFormProps) {
 
   const handleSubmit = (values: ISegmentBase) => {
     if (isNew) {
-      return createSegment(currentNamespace?.key, values);
+      return createSegment(currentNamespace.key, values);
     }
-    return updateSegment(currentNamespace?.key, segment?.key, values);
+    return updateSegment(currentNamespace.key, segment?.key, values);
   };
 
   const initialValues: ISegmentBase = {

--- a/src/components/segments/SegmentTable.tsx
+++ b/src/components/segments/SegmentTable.tsx
@@ -152,7 +152,7 @@ export default function SegmentTable(props: SegmentTableProps) {
                   <th
                     key={header.id}
                     scope="col"
-                    className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900"
+                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                   >
                     <div
                       className="group inline-flex cursor-pointer"
@@ -186,7 +186,7 @@ export default function SegmentTable(props: SegmentTableProps) {
                   <th
                     key={header.id}
                     scope="col"
-                    className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900"
+                    className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                   >
                     {header.isPlaceholder
                       ? null

--- a/src/components/settings/namespaces/NamespaceListbox.tsx
+++ b/src/components/settings/namespaces/NamespaceListbox.tsx
@@ -38,7 +38,7 @@ export default function NamespaceListbox(props: NamespaceLisboxProps) {
       }))}
       selected={{
         ...currentNamespace,
-        displayValue: currentNamespace?.name || ''
+        displayValue: currentNamespace.name || ''
       }}
       setSelected={setCurrentNamespace}
     />

--- a/src/components/settings/namespaces/NamespaceTable.tsx
+++ b/src/components/settings/namespaces/NamespaceTable.tsx
@@ -186,7 +186,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
       {namespaces.length >= searchThreshold && (
         <Searchbox className="mb-6" value={filter ?? ''} onChange={setFilter} />
       )}
-      <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+      <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
           <div className="relative overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-md">
             <table className="min-w-full table-fixed divide-y divide-gray-300">
@@ -198,7 +198,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
                         <th
                           key={header.id}
                           scope="col"
-                          className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900"
+                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                         >
                           <div
                             className="group inline-flex cursor-pointer"
@@ -232,7 +232,7 @@ export default function NamespaceTable(props: NamespaceTableProps) {
                         <th
                           key={header.id}
                           scope="col"
-                          className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900"
+                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                         >
                           {header.isPlaceholder
                             ? null

--- a/src/components/settings/tokens/TokenTable.tsx
+++ b/src/components/settings/tokens/TokenTable.tsx
@@ -133,7 +133,7 @@ export default function TokenTable(props: TokenTableProps) {
       {tokens.length >= searchThreshold && (
         <Searchbox className="mb-6" value={filter ?? ''} onChange={setFilter} />
       )}
-      <div className="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
+      <div className="-mx-4 -my-2 overflow-x-auto sm:-mx-6 lg:-mx-8">
         <div className="inline-block min-w-full py-2 align-middle md:px-6 lg:px-8">
           <div className="relative overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-md">
             <table className="min-w-full table-fixed divide-y divide-gray-300">
@@ -145,7 +145,7 @@ export default function TokenTable(props: TokenTableProps) {
                         <th
                           key={header.id}
                           scope="col"
-                          className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900"
+                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                         >
                           <div
                             className="group inline-flex cursor-pointer"
@@ -179,7 +179,7 @@ export default function TokenTable(props: TokenTableProps) {
                         <th
                           key={header.id}
                           scope="col"
-                          className="py-3.5 px-3 text-left text-sm font-semibold text-gray-900"
+                          className="px-3 py-3.5 text-left text-sm font-semibold text-gray-900"
                         >
                           {header.isPlaceholder
                             ? null


### PR DESCRIPTION
Fixes: FLI-297

1. Reset console form when current namespace changes
2. Removes unnecessary optional `?` from `currentNamespace`
3. Some tailwind CSS formatting order changes, likely from prettier-tailwind version change

![Kapture 2023-04-04 at 20 54 29](https://user-images.githubusercontent.com/209477/229954447-b15e1b3e-50a3-4040-b3bf-aaefe8c3fe4a.gif)
